### PR TITLE
Follow redirects

### DIFF
--- a/fhir_client.gemspec
+++ b/fhir_client.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'oauth2', '>= 1.1'
   spec.add_dependency 'rack', '>= 1.5'
   spec.add_dependency 'faraday', '~> 2.0'
+  spec.add_dependency 'faraday-follow_redirects'
   spec.add_dependency 'tilt', '>= 1.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'faraday/follow_redirects'
 require 'nokogiri'
 require 'addressable/uri'
 require 'oauth2'
@@ -371,7 +372,9 @@ module FHIR
     private
 
     def faraday_connection
-      Faraday.new(proxy: proxy)
+      Faraday.new(proxy: proxy) do |con|
+        con.response :follow_redirects
+      end
     end
 
     def base_path(path)
@@ -399,8 +402,8 @@ module FHIR
           resource.to_json
         elsif format_specified.downcase == 'application/x-www-form-urlencoded'
           # Special case where this is a search body and not a resource.
-          # Leave as hash because underlying libraries automatically URL encode it.
-          resource
+          # URL-encode the hash.
+          resource.to_param
         else
           resource.to_xml
         end

--- a/lib/fhir_client/version.rb
+++ b/lib/fhir_client/version.rb
@@ -1,5 +1,5 @@
 module FHIR
   class Client
-    VERSION = '6.0.0'.freeze
+    VERSION = '6.0.1'.freeze
   end
 end


### PR DESCRIPTION
This also fixes an unrelated bug, where search bodies were not being URL-encoded. The rest_client gem translated a hash to a URL-encoded string, but this needs to be done explicitly with faraday (though there's more than one way to do it).